### PR TITLE
Fix 503-service-unavailable issue in compilerd

### DIFF
--- a/services/code.service.js
+++ b/services/code.service.js
@@ -65,7 +65,6 @@ const _runScript = async (cmd, res, runMemoryCheck = false) => {
              */
             gc()
             await new Promise(resolve => setTimeout(resolve, 2000))
-            isChildKilled = false
             // need some way to know from the error message that memory is the issue
             e.message = e.message + ' Process killed due to Memory Limit Exceeded'
         }

--- a/services/code.service.js
+++ b/services/code.service.js
@@ -41,7 +41,6 @@ const _runScript = async (cmd, res, runMemoryCheck = false) => {
                     }
                 }
             }, 50)
-            // low - 5, high - 100
         }
 
         const execPromise = exec(cmd)

--- a/services/code.service.js
+++ b/services/code.service.js
@@ -40,7 +40,8 @@ const _runScript = async (cmd, res, runMemoryCheck = false) => {
                         _respondWithMemoryExceeded(res)
                     }
                 }
-            }, 100)
+            }, 50)
+            // low - 5, high - 100
         }
 
         const execPromise = exec(cmd)

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
 if [ -z "${OUTBOUND_TRAFFIC_ALLOW}" ] || [ "${OUTBOUND_TRAFFIC_ALLOW}" = "false" ]; then
     iptables -I OUTPUT -o eth2 -j DROP
 fi
-su -s /bin/sh runner -c 'node /usr/bin/server.js'
+su -s /bin/sh runner -c 'node --expose-gc /usr/bin/server.js'

--- a/tests/data/testJson.js
+++ b/tests/data/testJson.js
@@ -232,6 +232,21 @@ const testCases = [
         }
     },
     {
+        name: "MLE test 3",
+        reqObject: {
+            language: "python",
+            script:
+                "a = [100]\n" +
+                "for i in a:\n" +
+                "    a.append(i)\n"
+        },
+        expectedResponse: {
+            val: "Memory limit exceeded",
+            status: 200,
+            error: 1
+        }
+    },
+    {
         name: "OPEN AI test promptv1",
         reqObject: {
             language: "promptv1",

--- a/tests/data/testJson.js
+++ b/tests/data/testJson.js
@@ -208,6 +208,30 @@ const testCases = [
         }
     },
     {
+        name: "MLE test 2",
+        reqObject: {
+            language: "python",
+            script:
+                "import time\n" +
+                "def consume_memory(target_mb, duration_sec):\n" +
+                "    float_size = 8\n" +
+                "    floats_per_mb = (1024 * 1024) // float_size\n" +
+                "    total_floats = target_mb * floats_per_mb\n" +
+                "    iterations = int(duration_sec / 0.1)\n" +
+                "    floats_per_iteration = total_floats // iterations\n" +
+                "    memory_hog = []\n" +
+                "    for _ in range(iterations):\n" +
+                "        memory_hog.extend([0.0] * floats_per_iteration)\n" +
+                "        time.sleep(0.1)\n" +
+                "consume_memory(1000, 1)\n"
+        },
+        expectedResponse: {
+            val: "Memory limit exceeded",
+            status: 200,
+            error: 1
+        }
+    },
+    {
         name: "OPEN AI test promptv1",
         reqObject: {
             language: "promptv1",


### PR DESCRIPTION
## Issue:
 - When killing the main process in case `(usedMemory > 425M)`, we were not cleaning up the child process and hence the next incoming request assigned to the same container used to give 503 since container used to get killed by GCP while handling the request.

## Fix:
Fix has to go in 2 parts :
 - Detection:
   - Reduced the check from `(usedMemory > 425M)` to `(usedMemory > 400M)` to detect faster
   - Reduced the setInterval for memory check from `250ms` to `50ms` to react faster.
 - Handling:
   - Kill the child instead of killing the parent and wait for the child to get killed.
   - Add GC() to clean up memory and add 2sec wait to make sure GC is done.

## Testing:
 - Tested using failed jobs picked up from prod using assessment -  https://quadrangle.kalvium.org/assessment/503_fix_compilerd/
 - Added the same as test cases in the repo.