### PR TITLE
Fix the logging message in case of validation failure from openAI

### DIFF
--- a/services/code.service.js
+++ b/services/code.service.js
@@ -165,7 +165,7 @@ const _executePrompt = async (
 
             const validatedData = schema.validate(openAIResponse)
             if (validatedData.error || openAIResponse.points !== points) {
-                logger.error(`The response received from Open AI failed the validation check: ${validatedData}`)
+                logger.error(`The response received from Open AI failed the validation check: ${JSON.stringify(validatedData)}`)
                 ++errorResponsesCount
             } else {
                 allValidResponses.push(openAIResponse)


### PR DESCRIPTION
- Add `JSON.stringify` method to the error object