### PR TITLE
Update memory limits for Nodejs

### DIFF
--- a/configs/language.config.js
+++ b/configs/language.config.js
@@ -36,7 +36,7 @@ const LANGUAGES_CONFIG = {
         run: 'node solution.js',
         timeout: 10,
         filename: 'solution.js',
-        memory: ALLOWED_RAM * ONE_MB,
+        memory: 2 * ALLOWED_RAM * ONE_MB,
     },
     [RUBY]: {
         compile: 'ruby -c solution.rb',

--- a/configs/language.config.js
+++ b/configs/language.config.js
@@ -36,7 +36,7 @@ const LANGUAGES_CONFIG = {
         run: 'node solution.js',
         timeout: 10,
         filename: 'solution.js',
-        memory: 786432, // nodev20 expects more initial memory
+        memory: 786432, // Node.js v20 requires more initial memory, so initialize it to around 780MB (1.5 * 512MB). This value is higher than the previous 512MB but below 1GB to ensure ulimit catches excessive memory use without the GCR container being killed.
     },
     [RUBY]: {
         compile: 'ruby -c solution.rb',

--- a/configs/language.config.js
+++ b/configs/language.config.js
@@ -36,7 +36,7 @@ const LANGUAGES_CONFIG = {
         run: 'node solution.js',
         timeout: 10,
         filename: 'solution.js',
-        memory: 2 * ALLOWED_RAM * ONE_MB,
+        memory: 786432, // nodev20 expects more initial memory
     },
     [RUBY]: {
         compile: 'ruby -c solution.rb',


### PR DESCRIPTION
### Added : 
- Added new memory limits for Nodejs when running with ulimit. This change comes as part of upgrading base image of `alpine node` to major version 20. This fixes the error `Fatal process OOM in Failed to reserve virtual memory for CodeRange`.