### PR TITLE
fix: Script execution failure on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
### Summary

This pull request addresses an issue where scripts in the repo encountered execution failures when checked out on a Windows system, copied to a Docker container based on Alpine (which is a Linux distribution), and executed there.

This was primarily due to Git converting Unix-style LF line endings to Windows-style CRLF line endings, causing script syntax errors and failures during execution.
By introducing a .gitattributes file and configuring Git appropriately, we ensure consistent handling of line endings across different platforms.

### Changes Made

- Added a .gitattributes file to the repository.
- Configured Git to handle line endings automatically based on file types.
- Specifically set LF line endings for shell script files (*.sh) to ensure compatibility with Unix-like environments.

Fixes: #16 