### PR TITLE
Enable request interception in puppeteer

### DIFF
--- a/services/code.service.js
+++ b/services/code.service.js
@@ -650,6 +650,13 @@ const _runTests = async () => {
         })
         const page = await browser.newPage()
 
+        await page.setRequestInterception(true)
+
+        page.on('request', (request) => {
+            if (request.isInterceptResolutionHandled()) return
+            request.continue()
+        })
+
         page.on('requestfailed', request => {
             logger.error(`Request to ${request.url()} failed with reason ${request.abortErrorReason()}`)
         })


### PR DESCRIPTION
### Fix : 
- Enable request interception in puppeteer to handle failed requests to static server.