### PR TITLE
Fix: remove backticks from SQL queries for SQLite compatibility

### DIFF
--- a/services/code.service.js
+++ b/services/code.service.js
@@ -405,6 +405,10 @@ const _executeStatement = (db, sql) => {
     })
 }
 
+const _generateStatement = (sql) => {
+    return sql.replace(/`([^`]+\.[^`]+)`/g, '$1');
+}
+
 const _executeSqlQueries = async (dbPath, queries) => {
     const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READWRITE, (err) => {
         if (err) {
@@ -422,7 +426,7 @@ const _executeSqlQueries = async (dbPath, queries) => {
             return { data: [] }
         }
         for (const statement of ast.statement) {
-            sqlStatements.push(generate(statement))
+            sqlStatements.push(_generateStatement(generate(statement)))
         }
     } catch (err) {
         db.close()


### PR DESCRIPTION
Problem Description

The sqlgenerate module currently wraps table_name.column_name inside backticks. This syntax is not supported by SQLite, causing errors when running SQL queries. SQLite expects table and column names to be unquoted or wrapped in double quotes.

Short-Term Fix
To address this issue, we have implemented a regular expression to remove the backticks from the generated SQL queries. This ensures compatibility with SQLite without affecting the overall functionality of the module.

Changes Made:
        Added a regex pattern to identify and remove backticks from table_name.column_name expressions in SQL queries.

Long-Term Fix
To build our own module or find a module that can regenerate sql statements from AST.