### PR TITLE
Upgrade `promptv1` from gpt4 to current stable version of gpt4o

### DIFF
--- a/configs/language.config.js
+++ b/configs/language.config.js
@@ -46,7 +46,7 @@ const LANGUAGES_CONFIG = {
         memory: ALLOWED_RAM * ONE_MB,
     },
     [PROMPTV1]: {
-        model: 'gpt-4-1106-preview',
+        model: 'gpt-4o-2024-05-13',
     },
     [PROMPTV2]: {
         model: 'gpt-3.5-turbo-1106',


### PR DESCRIPTION
- Updated the current `promptv1` from `GPT-4` to `GPT-4o`
- The older version of `prompv1` - `gpt-4-1106-preview`
- The current version of `promptv1` - `gpt-4o-2024-05-13`