### PR TITLE
Fix cleanup for multifile executions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/node:20.13.0-alpine
 
 ENV PYTHONUNBUFFERED=1
 RUN set -ex && \
-    apk add --no-cache gcc g++ musl-dev python3 openjdk17 ruby iptables ip6tables
+    apk add --no-cache gcc g++ musl-dev python3 openjdk17 ruby iptables ip6tables curl
 
 RUN set -ex && \
     apk add --no-cache chromium lsof

--- a/services/code.service.js
+++ b/services/code.service.js
@@ -827,7 +827,7 @@ const _executeMultiFile = async (req, res, response) => {
         await _cleanUpDir(appConfig.multifile.workingDir, appConfig.multifile.submissionFileDownloadPath)
         response.output = jasmineResults
     } catch (err) {
-        _postCleanUp(req.type, staticServerInstance, jasmineServer)
+        await _postCleanUp(req.type, staticServerInstance, jasmineServer)
         if (err.message === 'No package.json found' || err.message.includes('Browser was not found at')) {
             throw err
         } else {


### PR DESCRIPTION
### Added : 
- Added post cleanup for multifile executions which should handle all cleanup activities for a given request.

### Improvements : 
- Moved the logic from pre cleanup to post cleanup to have better control and handling. This makes sure that each individual request is responsible for doing all it's cleanup before exiting. 